### PR TITLE
Replace iconv with iconv-lite so cross-platform builds can work

### DIFF
--- a/lib/decoder.js
+++ b/lib/decoder.js
@@ -1,4 +1,4 @@
-var Iconv = require('iconv').Iconv;
+var Iconv = require('iconv-lite');
 var xsettings = require('x11-xsettings');
 
 exports.decode = function(type, data) {
@@ -8,10 +8,9 @@ exports.decode = function(type, data) {
     switch (type) {
         case 'STRING':
             result = [];
-            var converter = new Iconv('ISO-8859-1', 'UTF-8');
             for (i = 0; i < data.length; ++i) {
                 if (data[i] === 0) {
-                    result.push(converter.convert(data.slice(init, i)));
+                    result.push(Iconv.decode(data.slice(init, i), 'UTF-8'));
                     init = i + 1;
                 }
             }

--- a/lib/encoder.js
+++ b/lib/encoder.js
@@ -1,4 +1,4 @@
-var Iconv = require('iconv').Iconv;
+var Iconv = require('iconv-lite');
 var xsettings = require('x11-xsettings');
 
 exports.encode = function(type, data, null_terminated) {
@@ -7,11 +7,10 @@ exports.encode = function(type, data, null_terminated) {
     var length;
     switch (type) {
         case 'STRING':
-            var converter = new Iconv('UTF-8', 'ISO-8859-1');
             new_data = [];
             length = 0;
             data.forEach(function(el, index) {
-                var conv_buf = converter.convert(new Buffer(el));
+                var conv_buf = Iconv.decode(new Buffer(el), 'ISO-8859-1');
                 new_data.push(conv_buf);
                 length += conv_buf.length;
                 if ((index !== data.length - 1) || null_terminated) {

--- a/package.json
+++ b/package.json
@@ -16,22 +16,21 @@
         "encoder",
         "codec"
     ],
-    "author": "Santiago Gimeno",
-    "license": "ISC",
+    "author": {
+        "name": "Santiago Gimeno",
+        "email": "santiago.gimeno@gmail.com"
+    },
+    "license": {
+        "type": "ISC",
+        "url": "https://github.com/santigimeno/node-x11-prop/blob/master/LICENSE"
+    },
     "dependencies": {
         "async": "~0.8.0",
-        "iconv": "^2.0.7",
+        "iconv-lite": "^0.5.0",
         "x11-xsettings": "~0.0.1"
     },
     "peerDependencies": {
         "x11": ">=0.7.1"
-    },
-    "author": {
-        "name" : "Santiago Gimeno",
-        "email": "santiago.gimeno@gmail.com"
-    },"license": {
-        "type": "ISC",
-        "url": "https://github.com/santigimeno/node-x11-prop/blob/master/LICENSE"
     },
     "readmeFilename": "README.md"
 }


### PR DESCRIPTION
The title says it all, really. The `iconv` module doesn't build correct for cross-platform apps (rendering Mac and Windows builds un-runnable), and `iconv-lite` also doesn't use any native dependencies, the lightening node_modules some. Functionality is unchanged.